### PR TITLE
Full layout metadata, layout named valueList, dateformats

### DIFF
--- a/fmrest/const.py
+++ b/fmrest/const.py
@@ -10,6 +10,7 @@ PORTAL_PREFIX = 'portal_'
 TIMEOUT = int(os.environ.get('fmrest_timeout', 10))
 
 API_VERSIONS = ('v1', 'v2', 'vLatest')
+API_DATEFORMATS = ('0', '1', '2')
 API_PATH_PREFIX = '/fmi/data/{version}'
 API_PATH: Dict[str, Any] = {
     'meta': {

--- a/fmrest/server.py
+++ b/fmrest/server.py
@@ -7,7 +7,7 @@ from functools import wraps
 import requests
 from .utils import (request, build_portal_params, build_script_params,
                     filename_from_url, PlaceholderDict)
-from .const import (PORTAL_PREFIX, FMSErrorCode, API_VERSIONS, API_PATH_PREFIX,
+from .const import (PORTAL_PREFIX, FMSErrorCode, API_VERSIONS, API_DATEFORMATS, API_PATH_PREFIX,
                     API_PATH)
 from .exceptions import BadJSON, FileMakerError, RecordError
 from .record import Record
@@ -371,7 +371,8 @@ class Server(object):
                    scripts: Optional[Dict[str, List]] = None,
                    layout: Optional[str] = None,
                    request_layout: Optional[str] = None,
-                   response_layout: Optional[str] = None) -> Record:
+                   response_layout: Optional[str] = None,
+                    dateformats: Optional[str] = None) -> Record:
         """Fetches record with given ID and returns Record instance
 
         Parameters
@@ -403,6 +404,10 @@ class Server(object):
             Set the response layout. This is helpful, for example, if you
             want to limit the number of fields/portals being returned and have
             a dedicated response layout.
+        dateformats : str, optional
+            The date format. Use 0 for US (MM/DD/YYYY), 1 for file locale,
+            or 2 for ISO8601 (YYYY-MM-DD).
+            If not specified, the default value is 0.
         """
         if layout is not None:
             warnings.warn('layout parameter is deprecated and will be removed '
@@ -412,6 +417,9 @@ class Server(object):
                                   request_layout).format(record_id=record_id)
 
         params = build_portal_params(portals, True) if portals else {}
+
+        # Date format: 0-US (MM/DD/YYYY, default), 1-file locale, 2-ISO8601 (YYYY-MM-DD)
+        params['dateformats'] = dateformats if dateformats in API_DATEFORMATS else '0'
 
         # set response layout; layout param is only handled for backward-
         # compatibility
@@ -496,7 +504,8 @@ class Server(object):
                     scripts: Optional[Dict[str, List]] = None,
                     layout: Optional[str] = None,
                     request_layout: Optional[str] = None,
-                    response_layout: Optional[str] = None) -> Foundset:
+                    response_layout: Optional[str] = None,
+                    dateformats: Optional[str] = None) -> Foundset:
         """Requests all records with given offset and limit and returns result as
         (sorted) Foundset instance.
 
@@ -528,6 +537,10 @@ class Server(object):
             Set the response layout. This is helpful, for example, if you
             want to limit the number of fields/portals being returned and have
             a dedicated response layout.
+        dateformats : str, optional
+            The date format. Use 0 for US (MM/DD/YYYY), 1 for file locale,
+            or 2 for ISO8601 (YYYY-MM-DD).
+            If not specified, the default value is 0.
         """
         if layout is not None:
             warnings.warn('layout parameter is deprecated and will be removed '
@@ -538,6 +551,9 @@ class Server(object):
         params = build_portal_params(portals, True) if portals else {}
         params['_offset'] = offset
         params['_limit'] = limit
+
+        # Date format: 0-US (MM/DD/YYYY, default), 1-file locale, 2-ISO8601 (YYYY-MM-DD)
+        params['dateformats'] = dateformats if dateformats in API_DATEFORMATS else '0'
 
         # set response layout; layout param is only handled for backward-
         # compatibility
@@ -564,7 +580,8 @@ class Server(object):
              scripts: Optional[Dict[str, List]] = None,
              layout: Optional[str] = None,
              request_layout: Optional[str] = None,
-             response_layout: Optional[str] = None) -> Foundset:
+             response_layout: Optional[str] = None,
+             dateformats: Optional[str] = None) -> Foundset:
         """Finds all records matching query and returns result as a Foundset instance.
 
         Parameters
@@ -605,6 +622,10 @@ class Server(object):
             Set the response layout. This is helpful, for example, if you
             want to limit the number of fields/portals being returned and have
             a dedicated response layout.
+        dateformats : str, optional
+            The date format. Use 0 for US (MM/DD/YYYY), 1 for file locale,
+            or 2 for ISO8601 (YYYY-MM-DD).
+            If not specified, the default value is 0.
         """
         if layout is not None:
             warnings.warn('layout parameter is deprecated and will be removed '
@@ -617,6 +638,8 @@ class Server(object):
             'sort': sort,
             'limit': str(limit),
             'offset': str(offset),
+            # Date format: 0-US (MM/DD/YYYY, default), 1-file locale, 2-ISO8601 (YYYY-MM-DD)
+            'dateformats': dateformats if dateformats in API_DATEFORMATS else '0',
             # "layout" param is only handled for backwards-compatibility
             'layout.response': layout if layout else response_layout
         }

--- a/fmrest/server.py
+++ b/fmrest/server.py
@@ -853,6 +853,50 @@ class Server(object):
 
         return response
 
+    def get_layout_valueList(self, name: str, layout: Optional[str] = None):
+        """Fetch layout metadata and return the 'name' valueList
+        suitable to use in a Form Select (tuple)
+        Retrieves layout metadata and returns a list of "name" values
+        for use in a form SELECT (tuple)
+
+        Example:
+            values = fms.get_layout_valueList()
+            -> (('a','A'), ('b','B'), ('c','C'))
+
+        Parameters
+        -----------
+        name : str
+            The list name to retreive values
+        fms : object
+            fmrest instance to query
+        layout : str, optional
+            Sets the layout name for this request. This takes precedence over
+            the value stored in the Server instance's layout attribute
+        """
+        target_layout = layout if layout else self.layout
+        metadata = self.get_layout_metadata(target_layout)
+        valueLists = metadata.get('valueLists', None)
+
+        # Initializing the list for the Select form
+        options = []
+
+        # As the API returns the same valueList several times,
+        # initialize a set to keep track of names already encountered.
+        encountered_names = set()
+
+        # Browse the elements of the JSON object
+        for item in valueLists:
+            if item['name'] == name and item['name'] not in encountered_names:
+                encountered_names.add(item['name'])
+
+                evaluation_values = item['values']
+                for value in evaluation_values:
+                    actual_value = value['value']
+                    display_value = value['displayValue']
+                    options.append((actual_value, display_value))
+
+        return tuple(options)
+
     def _call_filemaker(self, method: str, path: str,
                         data: Optional[Dict] = None,
                         params: Optional[Dict] = None,

--- a/fmrest/server.py
+++ b/fmrest/server.py
@@ -820,11 +820,13 @@ class Server(object):
 
     @_with_auto_relogin
     def get_layout(self, layout: Optional[str] = None) -> Dict:
-        """Fetches layout metadata and returns Dict instance
+        """Fetches layout metadata and returns "fieldMetaData" Dict instance
 
         Parameters
         -----------
-        none
+        layout : str, optional
+            Sets the layout name for this request. This takes precedence over
+            the value stored in the Server instance's layout attribute
         """
         target_layout = layout if layout else self.layout
         path = self._get_api_path('meta.layouts') + f'/{target_layout}'
@@ -832,6 +834,24 @@ class Server(object):
         response = self._call_filemaker('GET', path)
 
         return response.get('fieldMetaData', None)
+
+    @_with_auto_relogin
+    def get_layout_metadata(self, layout: Optional[str] = None) -> Dict:
+        """Fetches layout metadata and returns Dict instance.
+        Contains: fieldMetaData, portalMetaData, valueLists
+
+        Parameters
+        -----------
+        layout : str, optional
+            Sets the layout name for this request. This takes precedence over
+            the value stored in the Server instance's layout attribute
+        """
+        target_layout = layout if layout else self.layout
+        path = self._get_api_path('meta.layouts') + f'/{target_layout}'
+
+        response = self._call_filemaker('GET', path)
+
+        return response
 
     def _call_filemaker(self, method: str, path: str,
                         data: Optional[Dict] = None,

--- a/fmrest/server.py
+++ b/fmrest/server.py
@@ -854,9 +854,7 @@ class Server(object):
         return response
 
     def get_layout_valueList(self, name: str, layout: Optional[str] = None):
-        """Fetch layout metadata and return the 'name' valueList
-        suitable to use in a Form Select (tuple)
-        Retrieves layout metadata and returns a list of "name" values
+        """Retrieves layout metadata and returns a list of "name" values
         for use in a form SELECT (tuple)
 
         Example:


### PR DESCRIPTION
The current version of fmrest limits the data returned by the _**get_layout**_ function to _fieldMetaData_, omitting _PortalMetaData_ and _valueLists_.
=> `return response.get('fieldMetaData', None)`

As I also needed access to the _valueLists_ for my own development, I had to modify fmrest directly. 

- To ensure backward compatibility, I've added a _**get_layout_metadata**_ function that returns ALL layout metadata.
- Based on this, added a _**get_layout_valueList(name: __str__)**_ function to retrieve a named valueList from a layout, formatted for direct use in a form's SELECT.
- Added optional _**dateformats**_ parameter to API requests.