### PR TITLE
Fix valueList without displayValue key

### DIFF
--- a/fmrest/server.py
+++ b/fmrest/server.py
@@ -875,8 +875,9 @@ class Server(object):
 
         for vlist in value_lists:
             if vlist['name'] == name:
-                values += [(v['value'], v['displayValue']) for v in vlist['values']]
+                values += [(v['value'], v.get('displayValue', '')) for v in vlist['values']]
                 break
+
 
         return values
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r', encoding='utf-8') as ld:
 
 setup(
     name='python-fmrest',
-    version='1.7.0',
+    version='1.7.1',
     python_requires='>=3.6',
     author='David Hamann',
     author_email='dh@davidhamann.de',


### PR DESCRIPTION
Just a quick fix to avoid a crash of the `get_value_list_values` function when a value list contains an empty entry and FileMaker does not return a `displayValue` key. 

```
['valueLists':
    [
        {'name': 'my_value_list',
         'type': 'customList',
         'values':
             [ 
                {'value': ''},
                {'displayValue': 'A', 'value': 'a'},
                {'displayValue': 'B', 'value': 'b'},
                {'displayValue': 'C', 'value': 'c'}
                ]
        }
    ]
]
```
In this case, the function set `displayValue` to an empty string `''`
```
[('', ''), ('a', 'A'), ('b', 'B'), ('c', 'C')]
```